### PR TITLE
Added GET record API for Recommendation Requests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -74,4 +74,15 @@ public class RecommendationRequestController extends ApiController{
         return savedRecommendationRequest;
     }
 
+    @Operation(summary= "Get a single recommendation request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RecommendationRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        return recommendationRequest;
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -161,7 +161,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase{
                 RecommendationRequest recommendationRequest = RecommendationRequest.builder()
                                 .requesterEmail("student4@email.com")
                                 .professorEmail("professor4@email.com")
-                                .explaination("letter4request")
+                                .explanation("letter4request")
                                 .dateRequested(ldt)
                                 .dateNeeded(ldt)
                                 .done(true)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -13,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -36,7 +38,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase{
     @MockBean
     UserRepository userRepository;
 
-    // Tests for GET /api/recommendationrequest/all
+    // Tests for GET /api/recommendationrequests/all
         
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
@@ -95,7 +97,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase{
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for POST /api/recommendationrequest/post...
+        // Tests for POST /api/recommendationrequests/post...
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
@@ -139,6 +141,64 @@ public class RecommendationRequestControllerTests extends ControllerTestCase{
                 String expectedJson = mapper.writeValueAsString(recommendationRequest3);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for GET /api/recommendationrequests?id=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/recommendationrequests?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest recommendationRequest = RecommendationRequest.builder()
+                                .requesterEmail("student4@email.com")
+                                .professorEmail("professor4@email.com")
+                                .explaination("letter4request")
+                                .dateRequested(ldt)
+                                .dateNeeded(ldt)
+                                .done(true)
+                                .build();
+
+                when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(recommendationRequest));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/recommendationrequests?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(recommendationRequest);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/recommendationrequests?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
         }
 
 }


### PR DESCRIPTION
In this PR, we implemented the single record GET API for Recommendation Request database and added tests for it.

Closes #22 