### PR TITLE
Create Dining Commons Menu Item Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "UCSBDiningCommonsMenuItems")
+@RequestMapping("/api/ucsbdiningcommonsmenuitems")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @Operation(summary= "List all ucsb dining commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+        Iterable<UCSBDiningCommonsMenuItem> menuItems = ucsbDiningCommonsMenuItemRepository.findAll();
+        return menuItems;
+    }
+
+    @Operation(summary= "Create a new menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+            @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name="name") @RequestParam String name,
+            @Parameter(name="station") @RequestParam String station)
+            throws JsonProcessingException {
+
+        UCSBDiningCommonsMenuItem menuItem = new UCSBDiningCommonsMenuItem();
+        menuItem.setDiningCommonsCode(diningCommonsCode);
+        menuItem.setName(name);
+        menuItem.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedMenuItem = ucsbDiningCommonsMenuItemRepository.save(menuItem);
+
+        return savedMenuItem;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
@@ -58,5 +59,16 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
         UCSBDiningCommonsMenuItem savedMenuItem = ucsbDiningCommonsMenuItemRepository.save(menuItem);
 
         return savedMenuItem;
+    }
+
+    @Operation(summary= "Get a single menu item")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem menuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return menuItem;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,309 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/ucsbdiningcommonsmenuitems/all
+        
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
+
+                // arrange
+                UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("1")
+                                .name("taco")
+                                .station("Mexican")
+                                .build();
+
+                UCSBDiningCommonsMenuItem item2 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("2")
+                                .name("waffle")
+                                .station("Breakfast")
+                                .build();
+
+                ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
+                expectedItems.addAll(Arrays.asList(item1, item2));
+
+                when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedItems);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/ucsbdiningcommonsmenuitems/post...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitems/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitems/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsbdiningcommonsmenuitem() throws Exception {
+                // arrange
+                UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("1")
+                                .name("taco")
+                                .station("Mexican")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.save(eq(item))).thenReturn(item);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ucsbdiningcommonsmenuitems/post?diningCommonsCode=1&name=taco&station=Mexican")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(item);
+                String expectedJson = mapper.writeValueAsString(item);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // // Tests for GET /api/ucsbdiningcommonsmenuitems?id=...
+
+        // @Test
+        // public void logged_out_users_cannot_get_by_id() throws Exception {
+        //         mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+        //                         .andExpect(status().is(403)); // logged out users can't get by id
+        // }
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+        //         // arrange
+        //         UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+        //                         .diningCommonsCode("1")
+        //                         .name("taco")
+        //                         .station("Mexican")
+        //                         .build();
+
+        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(item));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+
+        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+        //         String expectedJson = mapper.writeValueAsString(item);
+        //         String responseString = response.getResponse().getContentAsString();
+        //         assertEquals(expectedJson, responseString);
+        // }
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        //         // arrange
+
+        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+
+        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("EntityNotFoundException", json.get("type"));
+        //         assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+        // }
+
+
+        // // Tests for DELETE /api/ucsbdiningcommonsmenuitems?id=... 
+
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_can_delete_a_date() throws Exception {
+        //         // arrange
+        //         UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
+        //                         .diningCommonsCode("1")
+        //                         .name("taco")
+        //                         .station("Mexican")
+        //                         .build();
+
+        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(item));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         delete("/api/ucsbdiningcommonsmenuitems?id=15")
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
+
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+        // }
+        
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+        //                 throws Exception {
+        //         // arrange
+
+        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         delete("/api/ucsbdiningcommonsmenuitems?id=15")
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
+        // }
+
+        // // Tests for PUT /api/ucsbdates?id=... 
+
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+        //         // arrange
+
+        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        //         LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+        //         UCSBDate ucsbDateOrig = UCSBDate.builder()
+        //                         .name("firstDayOfClasses")
+        //                         .quarterYYYYQ("20222")
+        //                         .localDateTime(ldt1)
+        //                         .build();
+
+        //         UCSBDate ucsbDateEdited = UCSBDate.builder()
+        //                         .name("firstDayOfFestivus")
+        //                         .quarterYYYYQ("20232")
+        //                         .localDateTime(ldt2)
+        //                         .build();
+
+        //         String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+
+        //         when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         put("/api/ucsbdates?id=67")
+        //                                         .contentType(MediaType.APPLICATION_JSON)
+        //                                         .characterEncoding("utf-8")
+        //                                         .content(requestBody)
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+        //         verify(ucsbDateRepository, times(1)).findById(67L);
+        //         verify(ucsbDateRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
+        //         String responseString = response.getResponse().getContentAsString();
+        //         assertEquals(requestBody, responseString);
+        // }
+
+        
+        // @WithMockUser(roles = { "ADMIN", "USER" })
+        // @Test
+        // public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+        //         // arrange
+
+        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        //         UCSBDate ucsbEditedDate = UCSBDate.builder()
+        //                         .name("firstDayOfClasses")
+        //                         .quarterYYYYQ("20222")
+        //                         .localDateTime(ldt1)
+        //                         .build();
+
+        //         String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+
+        //         when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(
+        //                         put("/api/ucsbdates?id=67")
+        //                                         .contentType(MediaType.APPLICATION_JSON)
+        //                                         .characterEncoding("utf-8")
+        //                                         .content(requestBody)
+        //                                         .with(csrf()))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+        //         verify(ucsbDateRepository, times(1)).findById(67L);
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("UCSBDate with id 67 not found", json.get("message"));
+
+        //}
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -8,12 +8,10 @@ import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -21,10 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -128,182 +123,4 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
-
-        // // Tests for GET /api/ucsbdiningcommonsmenuitems?id=...
-
-        // @Test
-        // public void logged_out_users_cannot_get_by_id() throws Exception {
-        //         mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
-        //                         .andExpect(status().is(403)); // logged out users can't get by id
-        // }
-
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
-
-        //         // arrange
-        //         UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
-        //                         .diningCommonsCode("1")
-        //                         .name("taco")
-        //                         .station("Mexican")
-        //                         .build();
-
-        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(item));
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
-        //                         .andExpect(status().isOk()).andReturn();
-
-        //         // assert
-
-        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
-        //         String expectedJson = mapper.writeValueAsString(item);
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(expectedJson, responseString);
-        // }
-
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
-
-        //         // arrange
-
-        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
-        //                         .andExpect(status().isNotFound()).andReturn();
-
-        //         // assert
-
-        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("EntityNotFoundException", json.get("type"));
-        //         assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
-        // }
-
-
-        // // Tests for DELETE /api/ucsbdiningcommonsmenuitems?id=... 
-
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_can_delete_a_date() throws Exception {
-        //         // arrange
-        //         UCSBDiningCommonsMenuItem item = UCSBDiningCommonsMenuItem.builder()
-        //                         .diningCommonsCode("1")
-        //                         .name("taco")
-        //                         .station("Mexican")
-        //                         .build();
-
-        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(item));
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         delete("/api/ucsbdiningcommonsmenuitems?id=15")
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
-
-        //         // assert
-        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
-        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
-
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
-        // }
-        
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
-        //                 throws Exception {
-        //         // arrange
-
-        //         when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         delete("/api/ucsbdiningcommonsmenuitems?id=15")
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isNotFound()).andReturn();
-
-        //         // assert
-        //         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
-        // }
-
-        // // Tests for PUT /api/ucsbdates?id=... 
-
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_can_edit_an_existing_ucsbdate() throws Exception {
-        //         // arrange
-
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-        //         LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
-
-        //         UCSBDate ucsbDateOrig = UCSBDate.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt1)
-        //                         .build();
-
-        //         UCSBDate ucsbDateEdited = UCSBDate.builder()
-        //                         .name("firstDayOfFestivus")
-        //                         .quarterYYYYQ("20232")
-        //                         .localDateTime(ldt2)
-        //                         .build();
-
-        //         String requestBody = mapper.writeValueAsString(ucsbDateEdited);
-
-        //         when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         put("/api/ucsbdates?id=67")
-        //                                         .contentType(MediaType.APPLICATION_JSON)
-        //                                         .characterEncoding("utf-8")
-        //                                         .content(requestBody)
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
-
-        //         // assert
-        //         verify(ucsbDateRepository, times(1)).findById(67L);
-        //         verify(ucsbDateRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(requestBody, responseString);
-        // }
-
-        
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
-        //         // arrange
-
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-
-        //         UCSBDate ucsbEditedDate = UCSBDate.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt1)
-        //                         .build();
-
-        //         String requestBody = mapper.writeValueAsString(ucsbEditedDate);
-
-        //         when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.empty());
-
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         put("/api/ucsbdates?id=67")
-        //                                         .contentType(MediaType.APPLICATION_JSON)
-        //                                         .characterEncoding("utf-8")
-        //                                         .content(requestBody)
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isNotFound()).andReturn();
-
-        //         // assert
-        //         verify(ucsbDateRepository, times(1)).findById(67L);
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("UCSBDate with id 67 not found", json.get("message"));
-
-        //}
 }


### PR DESCRIPTION
In this PR we add UCSBDiningCommonsMenuItems Controller with GET and POST endpoints, with corresponding tests.

Closes #9 